### PR TITLE
Added - Custom Query text box for User to customize Query as per need

### DIFF
--- a/force-app/main/default/classes/CustomMetadataService.cls
+++ b/force-app/main/default/classes/CustomMetadataService.cls
@@ -47,6 +47,12 @@ public with sharing class CustomMetadataService {
         return records;
     }
 
+    @AuraEnabled    
+    public static List<sObject> getCustomMetadataRecordsByQuery(String query){
+        List<sObject> records = Database.query(query);
+        return records;
+    }
+
     public class CustomMetadataDetailWrapper {
         @AuraEnabled public String label;
         @AuraEnabled public String pluralLabel;        

--- a/force-app/main/default/lwc/metadataViewer/metadataViewer.html
+++ b/force-app/main/default/lwc/metadataViewer/metadataViewer.html
@@ -57,6 +57,21 @@
 
     <!-- Records -->
     <template if:true={showRecords}>
+        <lightning-card class="slds-p-horizontal_small">
+            <p class="slds-m-around_xx-small slds-p-horizontal_small">
+                <lightning-textarea label="Query" 
+                                    max-length="5000" 
+                                    value={queryValue}
+                                    onchange={onQueryChange}
+                                    placeholder="Enter query to fetch results with sort & filters.">                    
+                </lightning-textarea>
+            </p>
+            <p class="slds-m-around_xx-small slds-p-horizontal_small">
+                <lightning-button label="Execute" variant="brand" onclick={onQueryExecute}>
+                </lightning-button>
+            </p>
+        </lightning-card>
+
         <lightning-datatable
             key-field="Id"
             data={data}


### PR DESCRIPTION
Added an option for the user to write the query which will help the user to customize the result as per need. 

Sample Screenshot - 

By default - Users will see the standard query
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/20971327/185441121-43a287f5-519c-4d1a-9789-10e3b07a0634.png">

Users will have an option to customize the query as per need and fetch customized results
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/20971327/185441356-7d957431-063e-4a92-b4a2-ea944a2cdd24.png">



closes #2 